### PR TITLE
add return-value to open() function

### DIFF
--- a/browser-deeplink.js
+++ b/browser-deeplink.js
@@ -169,10 +169,11 @@
      *
      * @public
      * @param {String} Deeplink URI
+     * @return {Boolean} true, if you're on a mobile device and the link was opened
      */
     var open = function(uri) {
         if (!isMobile()) {
-            return;
+            return false;
         }
 
         if (isAndroid() && !navigator.userAgent.match(/Firefox/)) {
@@ -195,6 +196,8 @@
         iframe.src = uri;
         iframe.setAttribute("style", "display:none;");
         document.body.appendChild(iframe);
+        
+        return true;
     }
 
     // Public API


### PR DESCRIPTION
For example, in the case of an onclick-handler for an a-tag, you can tell if the link was opened or not, e.g. in the handler: `if (deeplink.open(...)) event.preventDefault();` - so that, on desktops, the link can take you to a page with information about the app.